### PR TITLE
fix code-formatting

### DIFF
--- a/developer-guides/widgets.md
+++ b/developer-guides/widgets.md
@@ -71,7 +71,7 @@ This example requires an additional JS component located at `hello:js/widget.js`
 
 `js/widget.js`:
 
-````
+```javascript
 window.Widgets.components['system-login:settings'] = {
 
     section: {
@@ -83,11 +83,12 @@ window.Widgets.components['system-login:settings'] = {
     props: ['widget', 'config', 'form']
 
 };
+```
 
 `views/widget.php`:
 
 ```php
 <p>Hello Widget output.</p>
-````
+```
 
 **Note** A good example of a full Widget is located at `app/system/modules/user/widgets/login.php` in the Pagekit core.


### PR DESCRIPTION
The formattin in http://pagekit.com/docs/developer-guides/widgets is broken. Pull request fixes that.