### PR TITLE
Clarifying use of styles/scripts

### DIFF
--- a/developer-basics/views-templating.md
+++ b/developer-basics/views-templating.md
@@ -109,9 +109,10 @@ To generate a route to a static asset, use the `getStatic` method of the `UrlPro
 ```
 
 ### Include CSS in view file
-To include a CSS file in your view, call the `style helper` from the `View`. You can define its dependencies through the second parameter.
+To include a CSS file in your view, call the `style helper` from the `View`. The first parameter is a unique identifier for the stylesheet, while the second paramter is the path of the stylesheet where `theme:` is a reference to the root directory of a package named 'theme'. You can define its dependencies through the third parameter.
 
 ```
+<?php $view->style('name', 'package:dir/style.css') ?>
 <?php $view->style('theme', 'theme:css/theme.css') ?>
 <?php $view->style('theme', 'theme:css/theme.css', 'uikit') ?>
 <?php $view->style('theme', 'theme:css/theme.css', ['uikit', 'somethingelse']) ?>
@@ -120,7 +121,7 @@ To include a CSS file in your view, call the `style helper` from the `View`. You
 **Note** This will not directly output the required line in HTML. Instead, it will add the CSS file to the Pagekit Asset Manager. The stylesheet will be included in the `<head>` section of your theme.
 
 ### Include JS in view file
-To include a JavaScript file in your template, call the `script helper` from the `View`. You can define its dependencies through the second parameter.
+To include a JavaScript file in your template, call the `script helper` from the `View`. The first parameter is a unique identifier for the script, while the second paramter is the path of the stylesheet. You can define its dependencies through the third parameter.
 
 ```
 <?php $view->script('theme', 'theme:js/theme.js') ?>
@@ -128,7 +129,7 @@ To include a JavaScript file in your template, call the `script helper` from the
 <?php $view->script('theme', 'theme:js/theme.js', ['jquery', 'uikit']) ?>
 ```
 
-**Note** Internally, `style()` and `script()` each work with their own Asset Manager. As these are separate from each other, you can assign the same name to a CSS and JS file without conflict (both called `theme` in the above example).
+**Note** Internally, `style()` and `script()` each work with their own Asset Manager. As these are separate from each other, you can assign the same name to a CSS and JS file without conflict (both called `theme` in the above example). However, no two scripts or stylesheets may have the same identifier. For example, when adding two stylesheets, one could be named 'theme', and the other 'custom'. 
 
 ### Async and deferred script execution
 

--- a/developer-basics/views-templating.md
+++ b/developer-basics/views-templating.md
@@ -109,7 +109,7 @@ To generate a route to a static asset, use the `getStatic` method of the `UrlPro
 ```
 
 ### Include CSS in view file
-To include a CSS file in your view, call the `style helper` from the `View`. The first parameter is a unique identifier for the stylesheet, while the second paramter is the path of the stylesheet where `theme:` is a reference to the root directory of a package named 'theme'. You can define its dependencies through the third parameter.
+To include a CSS file in your view, call the `style helper` from the `View`. The first parameter is a unique identifier for the stylesheet, while the second parameter is the path of the stylesheet where `theme:` is a reference to the root directory of a package named 'theme'. You can define its dependencies through the third parameter.
 
 ```
 <?php $view->style('name', 'package:dir/style.css') ?>


### PR DESCRIPTION
Needs to be clear that two stylesheets or scripts cannot have the same name when all the examples overuse 'theme'