### PR TITLE
fix loader name

### DIFF
--- a/developer/vuejs-and-webpack.md
+++ b/developer/vuejs-and-webpack.md
@@ -76,7 +76,7 @@ module.exports = [
         },
         module: {
             loaders: [
-                { test: /\.vue$/, loader: "vue" }
+                { test: /\.vue$/, loader: "vue-loader" }
             ]
         }
     }


### PR DESCRIPTION
Otherwise we get:
>BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.  
>You need to specify 'vue-loader' instead of 'vue',